### PR TITLE
Update SimpleDetoursExportedFunctionTest function

### DIFF
--- a/msvc/corehook-test/detours_test.cpp
+++ b/msvc/corehook-test/detours_test.cpp
@@ -11,7 +11,7 @@ TEST_F(DetoursTest, SimpleDetoursExportedFunctionTest) {
     auto fileName = L"File.txt";
     LPCWSTR fileNamePtr = NULL;
 
-    _dt.DetourExportedFunction(fileName, &fileNamePtr);
+    EXPECT_EQ(_dt.DetourExportedFunction(fileName, &fileNamePtr), NO_ERROR);
 
     EXPECT_EQ(fileName, fileNamePtr);
 }

--- a/msvc/corehook-test/detours_test.cpp
+++ b/msvc/corehook-test/detours_test.cpp
@@ -11,7 +11,7 @@ TEST_F(DetoursTest, SimpleDetoursExportedFunctionTest) {
     auto fileName = L"File.txt";
     LPCWSTR fileNamePtr = NULL;
 
-    EXPECT_EQ(INVALID_HANDLE_VALUE, _dt.DetourExportedFunction(fileName, &fileNamePtr));
+    _dt.DetourExportedFunction(fileName, &fileNamePtr);
 
     EXPECT_EQ(fileName, fileNamePtr);
 }

--- a/msvc/corehook-test/simple_detours.h
+++ b/msvc/corehook-test/simple_detours.h
@@ -8,7 +8,7 @@ private:
 
 public:
     bool DetourUserFunction();
-    HANDLE DetourExportedFunction(LPCWSTR file, LPCWSTR *outFile);
+    LONG DetourExportedFunction(LPCWSTR file, LPCWSTR *outFile);
     int ShouldBypassDetourFunction();
 
 };

--- a/msvc/corehook-test/simple_detours_test.cpp
+++ b/msvc/corehook-test/simple_detours_test.cpp
@@ -112,27 +112,27 @@ HANDLE WINAPI CreateFileW_Detour(
 }
 
 // Detour CreateFileW and save the pointer to the first argument: 'lpFileName'
-HANDLE Detours::DetourExportedFunction(LPCWSTR file, LPCWSTR *outFile) {
+LONG Detours::DetourExportedFunction(LPCWSTR file, LPCWSTR *outFile) {
     LONG callback = 0;
     HOOK_TRACE_INFO hookHandle = { 0 };
 
     ULONG threadIdList = 0;
     const LONG threadCount = 1;
 
-    HANDLE hFile = NULL;
+    LONG error = ERROR_SUCCESS;
 
-    if (DetourInstallHook(
+    if ((error = DetourInstallHook(
         CreateFileW,
         CreateFileW_Detour,
         &callback,
-        &hookHandle) == NO_ERROR) {
+        &hookHandle)) == NO_ERROR) {
 
         DetourSetInclusiveACL(
             &threadIdList,
             threadCount,
             &hookHandle);
 
-        hFile = CreateFile(file,
+        CreateFile(file,
             GENERIC_READ,
             0,
             NULL,
@@ -145,5 +145,5 @@ HANDLE Detours::DetourExportedFunction(LPCWSTR file, LPCWSTR *outFile) {
         *outFile = _detourFileName;
     }
 
-    return hFile;
+    return error;
 }

--- a/msvc/corehook-test/simple_detours_test.cpp
+++ b/msvc/corehook-test/simple_detours_test.cpp
@@ -112,7 +112,6 @@ HANDLE WINAPI CreateFileW_Detour(
 }
 
 // Detour CreateFileW and save the pointer to the first argument: 'lpFileName'
-// The test file should not exist and so CreateFileW will return INVALID_HANDLE_VALUE
 HANDLE Detours::DetourExportedFunction(LPCWSTR file, LPCWSTR *outFile) {
     LONG callback = 0;
     HOOK_TRACE_INFO hookHandle = { 0 };


### PR DESCRIPTION
* Simplify the test to not depend on outside variables like the existence of the arbitrary `File.txt` and instead check the error code of the Detour installation function and whether the detour was successful. 