### PR TITLE
Update gtest library reference and modify trampoline size calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ For [CoreHook](https://github.com/unknownv2/CoreHook), the [Microsoft Detours](h
 Building the DLL requires Visual Studio and there are two options: You can build the DLL by using the `Visual Studio` (IDE or msbuild with the `Developer Command Prompt`) or nmake (it has been tested with `Visual Studio 2017` only). 
 
 ### Visual Studio
-You can find the [Visual Studio solution in the msvc folder](/msvc). You can choose a configuration (Debug or Release) and a platform (X86, X64, ARM, ARM64) and build. 
+You can find the [Visual Studio solution in the msvc folder](/msvc). You can choose a configuration (**Debug|Release**) and a platform (**X86|X64|ARM|ARM64**) and build. 
 
 An example for building the X64 `corehook64.dll` in the Release configuration:
 
 ```
-msbuild msvc/corehook.sln /p:Platform=x64 /p:Configuration=Release
+msbuild msvc/corehook.sln /p:Configuration=Release /p:Platform=x64
 ```
 ### NMAKE 
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,16 @@ For [CoreHook](https://github.com/unknownv2/CoreHook), the [Microsoft Detours](h
 
 ## Building
 
-Building the DLL requires Visual Studio and there are two options: You can build the DLL by using the Visual Studio IDE or nmake (it has been tested with `Visual Studio 2017` only). 
+Building the DLL requires Visual Studio and there are two options: You can build the DLL by using the `Visual Studio` (IDE or msbuild with the `Developer Command Prompt`) or nmake (it has been tested with `Visual Studio 2017` only). 
 
 ### Visual Studio
-You can find the [Visual Studio solution in the msvc folder](/msvc). You can choose a configuration (Debug or Release) and a target platform (X86, X64, ARM, ARM64) and build.
+You can find the [Visual Studio solution in the msvc folder](/msvc). You can choose a configuration (Debug or Release) and a platform (X86, X64, ARM, ARM64) and build. 
 
+An example for building the X64 `corehook64.dll` in the Release configuration:
+
+```
+msbuild msvc/corehook.sln /p:Platform=x64 /p:Configuration=Release
+```
 ### NMAKE 
 
 You can find the build environments for your Visual Studio installation normally at `C:\Program Files (x86)\Microsoft Visual Studio\2017\[ProductType]\VC\Auxiliary\Build`, where `[ProductType]` is your version of Visual Studio: **(Community, Professional, or Enterprise)**.

--- a/msvc/corehook-test/corehook-test.vcxproj
+++ b/msvc/corehook-test/corehook-test.vcxproj
@@ -124,7 +124,7 @@
   <ItemDefinitionGroup />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.0\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets" Condition="Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.0\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" />
+    <Import Project="..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.0\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.targets" Condition="Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.0\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.targets')" />
   </ImportGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -134,7 +134,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
     </ClCompile>
     <Link>
@@ -152,7 +152,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
     </ClCompile>
     <Link>
@@ -169,7 +169,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
     </ClCompile>
     <Link>
@@ -186,13 +186,16 @@
       <PreprocessorDefinitions>X64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
-      <WarningLevel>Level3</WarningLevel>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <WarningLevel>Level4</WarningLevel>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <AdditionalDependencies>aux_ulib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <IgnoreSpecificDefaultLibraries>
+      </IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -200,7 +203,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <Optimization>MaxSpeed</Optimization>
@@ -219,7 +222,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
@@ -235,7 +238,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
@@ -251,7 +254,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>X64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
@@ -267,6 +270,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.0\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.0\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.0\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.0\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.targets'))" />
   </Target>
 </Project>

--- a/msvc/corehook-test/packages.config
+++ b/msvc/corehook-test/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.0" targetFramework="native" />
+  <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static" version="1.8.0" targetFramework="native" />
 </packages>

--- a/src/barrier.cpp
+++ b/src/barrier.cpp
@@ -396,7 +396,6 @@ Returns:
 */
 
     DWORD CurrentId = GetCurrentThreadId();
-
     LONG Index;
 
     for (Index = 0; Index < MAX_THREAD_COUNT; Index++)

--- a/src/barrier.cpp
+++ b/src/barrier.cpp
@@ -741,9 +741,8 @@ Description:
 
 */
 
-    LONG                    NtStatus;
-    PTHREAD_RUNTIME_INFO   Runtime;
-
+    LONG NtStatus;
+    PTHREAD_RUNTIME_INFO Runtime;
 
     if (!IsValidPointer(ppCallback, sizeof(PVOID)))
     {
@@ -783,8 +782,8 @@ Description:
 
 */
 
-    LONG                        NtStatus;
-    PTHREAD_RUNTIME_INFO       Runtime;
+    LONG NtStatus;
+    PTHREAD_RUNTIME_INFO Runtime;
 
     if (!IsValidPointer(ppReturnAddress, sizeof(PVOID))) {
         THROW(STATUS_INVALID_PARAMETER, L"Invalid result storage specified.");
@@ -819,8 +818,8 @@ Description:
     the address of the return address of the hook handler.
 */
 
-    PTHREAD_RUNTIME_INFO       Runtime;
-    LONG                        NtStatus;
+    PTHREAD_RUNTIME_INFO Runtime;
+    LONG NtStatus;
 
     if (pppAddressOfReturnAddress == NULL) {
         THROW(STATUS_INVALID_PARAMETER, L"Invalid storage specified.");
@@ -857,8 +856,8 @@ Description:
     the application will be left in an unstable state!
 */
 
-    LONG                        NtStatus;
-    PTHREAD_RUNTIME_INFO       Runtime;
+    LONG NtStatus;
+    PTHREAD_RUNTIME_INFO Runtime;
 
     if (ppBackup == NULL) {
         THROW(STATUS_INVALID_PARAMETER, L"barrier.cpp - The given backup storage is invalid.");
@@ -894,8 +893,8 @@ Description:
     DetourBarrierBeginStackTrace().
 */
 
-    LONG                NtStatus;
-    PVOID*              AddrOfRetAddr;
+    LONG NtStatus;
+    PVOID *AddrOfRetAddr;
 
     if (!IsValidPointer(pBackup, 1)) {
         THROW(STATUS_INVALID_PARAMETER, L"barrier.cpp - The given stack backup pointer is invalid.");
@@ -945,8 +944,8 @@ Returns:
         Only supported since Windows XP.
 */
     
-    LONG                    NtStatus;
-    PVOID                   Backup = NULL;
+    LONG NtStatus;
+    PVOID Backup = NULL;
 
     if (dwFramesToCapture > 64) {
         THROW(STATUS_INVALID_PARAMETER_2, L"barrier.cpp - At maximum 64 modules are supported.");

--- a/src/barrier.h
+++ b/src/barrier.h
@@ -97,7 +97,6 @@ extern RTL_SPIN_LOCK        GlobalHookLock;
 
 #define DETOUR_SUCCESS(ntstatus)    SUCCEEDED(ntstatus)
 
-#define STATUS_SUCCESS              0
 #define RETURN                      { detour_set_last_error(STATUS_SUCCESS, STATUS_SUCCESS, L""); NtStatus = STATUS_SUCCESS; goto FINALLY_OUTRO; }
 #define FORCE(expr)                 { if(!DETOUR_SUCCESS(NtStatus = (expr))) goto THROW_OUTRO; }
 
@@ -140,7 +139,7 @@ void detour_zero_memory(_Out_writes_bytes_all_(Size) PVOID Dest,
 
 //////////////////////////////////////////////////////// NTSTATUS definitions
 
-
+#define STATUS_SUCCESS                   0
 #define STATUS_NOT_SUPPORTED             ((LONG)0xC00000BBL)
 #define STATUS_INTERNAL_ERROR            ((LONG)0xC00000E5L)
 #define STATUS_PROCEDURE_NOT_FOUND       ((LONG)0xC000007AL)

--- a/src/detours.cpp
+++ b/src/detours.cpp
@@ -1693,23 +1693,20 @@ ULONG GetTrampolineSize()
     ___TrampolineSize = static_cast<ULONG>(
         (reinterpret_cast<PBYTE>(Trampoline_ASM_X64_DATA) - reinterpret_cast<PBYTE>(Trampoline_ASM_X64_CODE)));
 
-    return ___TrampolineSize;
 #elif defined(DETOURS_X86)  
     ___TrampolineSize = static_cast<ULONG>(
         (reinterpret_cast<PBYTE>(Trampoline_ASM_X86_DATA) - DetourGetTrampolinePtr()));
 
-    return ___TrampolineSize;
 #elif defined(DETOURS_ARM)
     ___TrampolineSize = static_cast<ULONG>(
         (reinterpret_cast<PBYTE>(Trampoline_ASM_ARM_DATA) - reinterpret_cast<PBYTE>(Trampoline_ASM_ARM_CODE)));
 
-    return ___TrampolineSize;
 #elif defined(DETOURS_ARM64)
     ___TrampolineSize = static_cast<ULONG>(
         (reinterpret_cast<PBYTE>(Trampoline_ASM_ARM64_DATA) - reinterpret_cast<PBYTE>(Trampoline_ASM_ARM64_CODE)));
 
-    return ___TrampolineSize;
 #endif
+    return ___TrampolineSize;
 }
 
 UINT WINAPI BarrierIntro(_In_ DETOUR_TRAMPOLINE *pHandle,

--- a/src/detours.cpp
+++ b/src/detours.cpp
@@ -1784,7 +1784,7 @@ Description:
     if(!Exists)
     {        
         TlsGetCurrentValue(&Unit.TLS, &Info);
-        Info->Entries = reinterpret_cast<RUNTIME_INFO*>(detour_allocate_memory(TRUE, sizeof(RUNTIME_INFO) * MAX_HOOK_COUNT));
+        Info->Entries = static_cast<RUNTIME_INFO*>(detour_allocate_memory(TRUE, sizeof(RUNTIME_INFO) * MAX_HOOK_COUNT));
 
         if (Info->Entries == NULL) {
             goto DONT_INTERCEPT;
@@ -1933,8 +1933,8 @@ VOID detour_insert_trace_handle(PDETOUR_TRAMPOLINE pTrampoline)
 
 LONG detour_add_trampoline_to_global_list(PDETOUR_TRAMPOLINE pTrampoline)
 {
-    DWORD   dwIndex;
-    BOOL    bExists;
+    DWORD dwIndex;
+    BOOL bExists;
 
     // register in global HLS list
     detour_acquire_lock(&GlobalHookLock);
@@ -2019,7 +2019,7 @@ Returns:
 */
 
     LONG NtStatus = STATUS_INTERNAL_ERROR;
-    LONG error    = -1;
+    LONG error = -1;
     PDETOUR_TRAMPOLINE pTrampoline = NULL;
 
     // validate parameters
@@ -2387,10 +2387,10 @@ LONG WINAPI DetourTransactionCommitEx(_Out_opt_ PVOID **pppFailedPointer)
 #endif // DETOURS_X64
 
 #ifdef DETOURS_X86
-            PBYTE trampoline = DetourGetTrampolinePtr();
+            const PBYTE trampoline = DetourGetTrampolinePtr();
             const ULONG TrampolineSize = GetTrampolineSize();
     
-            PBYTE endOfTramp = (PBYTE)&o->pTrampoline->rbTrampolineCode;
+            const auto endOfTramp = &o->pTrampoline->rbTrampolineCode;
             memcpy(endOfTramp, trampoline, TrampolineSize);
             o->pTrampoline->HookIntro = BarrierIntro;
             o->pTrampoline->HookOutro = BarrierOutro;
@@ -2401,7 +2401,7 @@ LONG WINAPI DetourTransactionCommitEx(_Out_opt_ PVOID **pppFailedPointer)
 
             detour_set_trampoline_functions(o->pTrampoline, TrampolineSize);
 
-            PBYTE pbCode = detour_gen_jmp_immediate(o->pbTarget, (PBYTE)o->pTrampoline->Trampoline);
+            PBYTE pbCode = detour_gen_jmp_immediate(o->pbTarget, static_cast<PBYTE>(o->pTrampoline->Trampoline));
             
             pbCode = detour_gen_brk(pbCode, o->pTrampoline->pbRemain);
             *o->ppbPointer = o->pTrampoline->rbCode;
@@ -2409,11 +2409,11 @@ LONG WINAPI DetourTransactionCommitEx(_Out_opt_ PVOID **pppFailedPointer)
 #endif // DETOURS_X86
 
 #ifdef DETOURS_ARM
-            UCHAR * trampoline = DetourGetTrampolinePtr();
+            const PBYTE trampoline = DetourGetTrampolinePtr();
             const ULONG TrampolineSize = GetTrampolineSize();
  
-            PBYTE endOfTramp = (PBYTE)&o->pTrampoline->rbTrampolineCode;
-            PBYTE trampolineStart = align4(trampoline);
+            const auto endOfTramp = &o->pTrampoline->rbTrampolineCode;
+            const PBYTE trampolineStart = align4(trampoline);
             memcpy(endOfTramp, trampolineStart, TrampolineSize);
             o->pTrampoline->HookIntro = DETOURS_PBYTE_TO_PFUNC(BarrierIntro);
             o->pTrampoline->HookOutro = DETOURS_PBYTE_TO_PFUNC(BarrierOutro);
@@ -2441,7 +2441,7 @@ LONG WINAPI DetourTransactionCommitEx(_Out_opt_ PVOID **pppFailedPointer)
             PBYTE trampoline = DetourGetTrampolinePtr();
             const ULONG TrampolineSize = GetTrampolineSize();
 
-            PBYTE endOfTramp = (PBYTE)&o->pTrampoline->rbTrampolineCode;
+            const auto endOfTramp = &o->pTrampoline->rbTrampolineCode;
             memcpy(endOfTramp, trampoline, TrampolineSize);
             o->pTrampoline->HookIntro = BarrierIntro;
             o->pTrampoline->HookOutro = BarrierOutro;
@@ -2875,7 +2875,7 @@ LONG WINAPI DetourAttachEx(_Inout_ PVOID *ppPointer,
         }
 
         pbSrc += cFiller;
-        cbTarget = (LONG)(pbSrc - pbTarget);
+        cbTarget = static_cast<LONG>(pbSrc - pbTarget);
     }
 
 #if DETOUR_DEBUG

--- a/src/detours.cpp
+++ b/src/detours.cpp
@@ -2361,14 +2361,14 @@ LONG WINAPI DetourTransactionCommitEx(_Out_opt_ PVOID **pppFailedPointer)
 #endif // DETOURS_IA64
 
 #ifdef DETOURS_X64
-            const PBYTE trampoline = DetourGetTrampolinePtr();
+            const PBYTE trampolinePtr = DetourGetTrampolinePtr();
             const ULONG TrampolineSize = GetTrampolineSize();
        
-            const auto endOfTramp = &o->pTrampoline->rbTrampolineCode;
-            memcpy(endOfTramp, trampoline, TrampolineSize);
+            const auto trampolineCode = &o->pTrampoline->rbTrampolineCode;
+            memcpy(trampolineCode, trampolinePtr, TrampolineSize);
             o->pTrampoline->HookIntro = BarrierIntro;
             o->pTrampoline->HookOutro = BarrierOutro;
-            o->pTrampoline->Trampoline = endOfTramp;
+            o->pTrampoline->Trampoline = trampolineCode;
             o->pTrampoline->OldProc = o->pTrampoline->rbCode;
             o->pTrampoline->HookProc = o->pTrampoline->pbDetour;
             o->pTrampoline->IsExecutedPtr = new int();
@@ -2381,14 +2381,14 @@ LONG WINAPI DetourTransactionCommitEx(_Out_opt_ PVOID **pppFailedPointer)
 #endif // DETOURS_X64
 
 #ifdef DETOURS_X86
-            const PBYTE trampoline = DetourGetTrampolinePtr();
+            const PBYTE trampolinePtr = DetourGetTrampolinePtr();
             const ULONG TrampolineSize = GetTrampolineSize();
     
-            const auto endOfTramp = &o->pTrampoline->rbTrampolineCode;
-            memcpy(endOfTramp, trampoline, TrampolineSize);
+            const auto trampolineCode = &o->pTrampoline->rbTrampolineCode;
+            memcpy(trampolineCode, trampolinePtr, TrampolineSize);
             o->pTrampoline->HookIntro = BarrierIntro;
             o->pTrampoline->HookOutro = BarrierOutro;
-            o->pTrampoline->Trampoline = endOfTramp;
+            o->pTrampoline->Trampoline = trampolineCode;
             o->pTrampoline->OldProc = o->pTrampoline->rbCode;
             o->pTrampoline->HookProc = o->pTrampoline->pbDetour;
             o->pTrampoline->IsExecutedPtr = new int();
@@ -2403,15 +2403,15 @@ LONG WINAPI DetourTransactionCommitEx(_Out_opt_ PVOID **pppFailedPointer)
 #endif // DETOURS_X86
 
 #ifdef DETOURS_ARM
-            const PBYTE trampoline = DetourGetTrampolinePtr();
+            const PBYTE trampolinePtr = DetourGetTrampolinePtr();
             const ULONG TrampolineSize = GetTrampolineSize();
  
-            const auto endOfTramp = &o->pTrampoline->rbTrampolineCode;
-            const PBYTE trampolineStart = align4(trampoline);
-            memcpy(endOfTramp, trampolineStart, TrampolineSize);
+            const auto trampolineCode = &o->pTrampoline->rbTrampolineCode;
+            const PBYTE trampolineStart = align4(trampolinePtr);
+            memcpy(trampolineCode, trampolineStart, TrampolineSize);
             o->pTrampoline->HookIntro = DETOURS_PBYTE_TO_PFUNC(BarrierIntro);
             o->pTrampoline->HookOutro = DETOURS_PBYTE_TO_PFUNC(BarrierOutro);
-            o->pTrampoline->Trampoline = DETOURS_PBYTE_TO_PFUNC(endOfTramp);
+            o->pTrampoline->Trampoline = DETOURS_PBYTE_TO_PFUNC(trampolineCode);
             o->pTrampoline->OldProc = DETOURS_PBYTE_TO_PFUNC(o->pTrampoline->rbCode);
             o->pTrampoline->HookProc = DETOURS_PBYTE_TO_PFUNC(o->pTrampoline->pbDetour);
             o->pTrampoline->IsExecutedPtr = new int();
@@ -2425,26 +2425,26 @@ LONG WINAPI DetourTransactionCommitEx(_Out_opt_ PVOID **pppFailedPointer)
                           o->pTrampoline->OldProc[4], o->pTrampoline->OldProc[5], o->pTrampoline->OldProc[6], o->pTrampoline->OldProc[7],
                           o->pTrampoline->OldProc[8], o->pTrampoline->OldProc[9], o->pTrampoline->OldProc[10], o->pTrampoline->OldProc[11]));          
   
-            PBYTE pbCode = detour_gen_jmp_immediate(o->pbTarget, NULL, (PBYTE)o->pTrampoline->Trampoline);
+            PBYTE pbCode = detour_gen_jmp_immediate(o->pbTarget, NULL, static_cast<PBYTE>(o->pTrampoline->Trampoline));
             pbCode = detour_gen_brk(pbCode, o->pTrampoline->pbRemain);
             *o->ppbPointer = DETOURS_PBYTE_TO_PFUNC(o->pTrampoline->rbCode);
             UNREFERENCED_PARAMETER(pbCode);
 #endif // DETOURS_ARM
 
 #ifdef DETOURS_ARM64
-            PBYTE trampoline = DetourGetTrampolinePtr();
+            const PBYTE trampolinePtr = DetourGetTrampolinePtr();
             const ULONG TrampolineSize = GetTrampolineSize();
 
-            const auto endOfTramp = &o->pTrampoline->rbTrampolineCode;
-            memcpy(endOfTramp, trampoline, TrampolineSize);
+            const auto trampolineCode = &o->pTrampoline->rbTrampolineCode;
+            memcpy(trampolineCode, trampolinePtr, TrampolineSize);
             o->pTrampoline->HookIntro = BarrierIntro;
             o->pTrampoline->HookOutro = BarrierOutro;
-            o->pTrampoline->Trampoline = endOfTramp;
+            o->pTrampoline->Trampoline = trampolineCode;
             o->pTrampoline->OldProc = o->pTrampoline->rbCode;
             o->pTrampoline->HookProc = o->pTrampoline->pbDetour;
             o->pTrampoline->IsExecutedPtr = new int();
 
-            PBYTE pbCode = detour_gen_jmp_immediate(o->pbTarget, NULL, (PBYTE)o->pTrampoline->Trampoline);
+            PBYTE pbCode = detour_gen_jmp_immediate(o->pbTarget, NULL, static_cast<PBYTE>(o->pTrampoline->Trampoline));
             pbCode = detour_gen_brk(pbCode, o->pTrampoline->pbRemain);
             *o->ppbPointer = o->pTrampoline->rbCode;
             UNREFERENCED_PARAMETER(pbCode);

--- a/src/detours.cpp
+++ b/src/detours.cpp
@@ -1656,25 +1656,27 @@ static ULONG ___TrampolineSize = 0;
     extern "C" void*          Trampoline_ASM_ARM64_DATA();
 #endif
 
-UCHAR* DetourGetTrampolinePtr()
+PBYTE DetourGetTrampolinePtr()
 {
-// bypass possible Visual Studio debug jump table
+    // bypass possible Visual Studio debug jump table
+    PBYTE Ptr = NULL;
 #if defined(DETOURS_X64)
-    UCHAR* Ptr = (UCHAR*)Trampoline_ASM_x64;
+    Ptr = reinterpret_cast<UCHAR*>(Trampoline_ASM_x64);
 
 #elif defined(DETOURS_X86)
-    UCHAR* Ptr = (UCHAR*)Trampoline_ASM_x86;
+    Ptr = reinterpret_cast<UCHAR*>(Trampoline_ASM_x86);
 
 #elif defined DETOURS_ARM
-    UCHAR* Ptr = (UCHAR*)Trampoline_ASM_ARM_CODE;
+     Ptr = reinterpret_cast<(UCHAR*>(Trampoline_ASM_ARM_CODE);
 
 #elif defined DETOURS_ARM64
-    UCHAR* Ptr = (UCHAR*)Trampoline_ASM_ARM64_CODE;
+    Ptr = reinterpret_cast<UCHAR*>(Trampoline_ASM_ARM64_CODE);
+
 #endif
 
-    if(*Ptr == 0xE9)
+    if (*Ptr == 0xE9) {
         Ptr += *((int*)(Ptr + 1)) + 5;
-
+    }
 #ifdef DETOURS_X64
     return Ptr + 5 * 8;
 #else
@@ -1693,20 +1695,20 @@ ULONG GetTrampolineSize()
 
     return ___TrampolineSize;
 #else
-    UCHAR*      Ptr = DetourGetTrampolinePtr();
-    UCHAR*      BasePtr = Ptr;
-    ULONG       Signature;
-    ULONG       Index;
+    PBYTE Ptr = DetourGetTrampolinePtr();
+    PBYTE BasePtr = Ptr;
+    ULONG Signature;
+    ULONG Index;
 
     // search for signature
     for(Index = 0; Index < 2000 /* some always large enough value*/; Index++)
     {
-        Signature = *((ULONG*)Ptr);
+        Signature = *(reinterpret_cast<ULONG*>(Ptr));
 
-        if(Signature == 0x12345678)    
+        if(Signature == 0x12345678)
         {
-            ___TrampolineSize = (ULONG)(Ptr - BasePtr);
-            return ___TrampolineSize;          
+            ___TrampolineSize = static_cast<ULONG>(Ptr - BasePtr);
+            return ___TrampolineSize;
         }
 
         Ptr++;
@@ -1726,12 +1728,12 @@ Description:
     thread deadlock barrier.
 */
 
-    PTHREAD_RUNTIME_INFO        Info;
-    RUNTIME_INFO*                Runtime;
-    BOOL                         Exists;
+    PTHREAD_RUNTIME_INFO Info;
+    RUNTIME_INFO *Runtime;
+    BOOL Exists;
 
 #if defined(DETOURS_X64) || defined(DETOURS_ARM) || defined(DETOURS_ARM64)
-    pHandle = (PDETOUR_TRAMPOLINE)((PBYTE)(pHandle) - (sizeof(DETOUR_TRAMPOLINE) - DETOUR_TRAMPOLINE_CODE_SIZE));
+    pHandle = (PDETOUR_TRAMPOLINE)((PBYTE)(pHandle)-(sizeof(DETOUR_TRAMPOLINE) - DETOUR_TRAMPOLINE_CODE_SIZE));
 #endif
 
     DETOUR_TRACE(("detours: BarrierIntro() Handle=%p, ReturnAddr=%p, AddrOfReturnAddr=%p \n",
@@ -1861,16 +1863,18 @@ Description:
     save it in any efficient manner at this point of execution...
 */
 
-    RUNTIME_INFO*            Runtime;
-    PTHREAD_RUNTIME_INFO    Info;
+    RUNTIME_INFO *Runtime;
+    PTHREAD_RUNTIME_INFO Info;
 
 #if defined(DETOURS_X64) || defined(DETOURS_ARM) || defined(DETOURS_ARM64)
-        pHandle = (PDETOUR_TRAMPOLINE)((PBYTE)(pHandle)-(sizeof(DETOUR_TRAMPOLINE) - DETOUR_TRAMPOLINE_CODE_SIZE));
+    pHandle = (PDETOUR_TRAMPOLINE)((PBYTE)(pHandle)-(sizeof(DETOUR_TRAMPOLINE) - DETOUR_TRAMPOLINE_CODE_SIZE));
+
 #endif
 
     DETOUR_ASSERT(detour_acquire_self_protection(), L"detours.cpp - detour_acquire_self_protection()");
 
-    DETOUR_ASSERT(TlsGetCurrentValue(&Unit.TLS, &Info) && (Info != NULL), L"detours.cpp - TlsGetCurrentValue(&Unit.TLS, &Info) && (Info != NULL)");
+    DETOUR_ASSERT(TlsGetCurrentValue(&Unit.TLS, &Info) && (Info != NULL),
+        L"detours.cpp - TlsGetCurrentValue(&Unit.TLS, &Info) && (Info != NULL)");
 
     Runtime = &Info->Entries[pHandle->HLSIndex];
 
@@ -2012,9 +2016,9 @@ Returns:
 
 */
 
-    LONG                NtStatus = STATUS_INTERNAL_ERROR;
-    LONG                error    = -1;
-    PDETOUR_TRAMPOLINE  pTrampoline = NULL;
+    LONG NtStatus = STATUS_INTERNAL_ERROR;
+    LONG error    = -1;
+    PDETOUR_TRAMPOLINE pTrampoline = NULL;
 
     // validate parameters
     if (!IsValidPointer(pEntryPoint, 1)) {
@@ -2073,11 +2077,10 @@ A traced hook handle. If the hook is already removed, this method
 will still return STATUS_SUCCESS.
 */
 
-    LONG                    error = -1;
-
-    PDETOUR_TRAMPOLINE      Hook = NULL;
-    LONG                    NtStatus = -1;
-    BOOLEAN                 IsAllocated = FALSE;
+    LONG error = -1;
+    PDETOUR_TRAMPOLINE Hook = NULL;
+    LONG NtStatus = -1;
+    BOOLEAN IsAllocated = FALSE;
 
     if (!IsValidPointer(pHandle, sizeof(HOOK_TRACE_INFO))) {
         return FALSE;
@@ -2131,8 +2134,8 @@ about the implementation.
 
 */
 
-    LONG                NtStatus;
-    PDETOUR_TRAMPOLINE    Handle;
+    LONG NtStatus;
+    PDETOUR_TRAMPOLINE Handle;
 
     if (!detour_is_valid_handle(pHook, &Handle)) {
         THROW(STATUS_INVALID_PARAMETER_1, (PWCHAR)L"The given hook handle is invalid or already disposed.");
@@ -2197,7 +2200,7 @@ Parameters:
     The hook handle whose local ACL is going to be set.
 */
 
-    PDETOUR_TRAMPOLINE        Handle;
+    PDETOUR_TRAMPOLINE Handle;
 
     if (!detour_is_valid_handle(pHandle, &Handle)) {
         return STATUS_INVALID_PARAMETER_3;
@@ -2242,8 +2245,8 @@ Returns:
 
 */
 
-    LONG                NtStatus;
-    PDETOUR_TRAMPOLINE    Handle;
+    LONG NtStatus;
+    PDETOUR_TRAMPOLINE Handle;
 
     if (!detour_is_valid_handle(pHook, &Handle)) {
         THROW(STATUS_INVALID_PARAMETER_1, L"The given hook handle is invalid or already disposed.");
@@ -2283,7 +2286,7 @@ Parameters:
         The hook handle whose local ACL is going to be set.
 */
 
-    PDETOUR_TRAMPOLINE        Handle;
+    PDETOUR_TRAMPOLINE Handle;
 
     if (!detour_is_valid_handle(pHandle, &Handle)) {
         return STATUS_INVALID_PARAMETER_3;

--- a/src/trampolinex64.asm
+++ b/src/trampolinex64.asm
@@ -14,11 +14,14 @@
 ; prevents the SMC condition and uses RIP relative jumps...
 
 
-public Trampoline_ASM_x64
+public Trampoline_ASM_X64
+
+public Trampoline_ASM_X64_CODE
+public Trampoline_ASM_X64_DATA
 
 _TEXT SEGMENT
 
-Trampoline_ASM_x64 PROC
+Trampoline_ASM_X64 PROC
 
 NETIntro:
     ;void*            NETEntry; // fixed 0 (0) 
@@ -74,7 +77,8 @@ IsExecutedPtr:
     db 0
     db 0
     db 0
-    
+
+Trampoline_ASM_x64_CODE::
 ; ATTENTION: 64-Bit requires stack alignment (RSP) of 16 bytes!!
     ; Apply alignment trick: https://stackoverflow.com/a/9600102
     push rsp
@@ -201,7 +205,7 @@ TRAMPOLINE_EXIT:
     
     jmp qword ptr[rax] ; ATTENTION: In case of hook handler we will return to CALL_NET_OUTRO, otherwise to the caller...
     
-    
+Trampoline_ASM_X64_DATA::
 ; outro signature, to automatically determine code size
     db 78h
     db 56h

--- a/src/trampolinex64.asm
+++ b/src/trampolinex64.asm
@@ -15,7 +15,6 @@
 
 
 public Trampoline_ASM_X64
-
 public Trampoline_ASM_X64_CODE
 public Trampoline_ASM_X64_DATA
 

--- a/src/trampolinex86.asm
+++ b/src/trampolinex86.asm
@@ -5,9 +5,11 @@
 .model flat, c
 .code
 
-public Trampoline_ASM_x86@0
+public Trampoline_ASM_X86@0
 
-Trampoline_ASM_x86@0 PROC
+public Trampoline_ASM_X86_DATA
+
+Trampoline_ASM_X86@0 PROC
 
 ; Handle:       1A2B3C05h
 ; NETEntry:     1A2B3C03h
@@ -42,7 +44,7 @@ Trampoline_ASM_x86@0 PROC
         jmp TRAMPOLINE_EXIT
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; call hook handler or original method...
-CALL_NET_ENTRY:    
+CALL_NET_ENTRY:
     
 ; call NET intro
     push ecx
@@ -70,7 +72,7 @@ CALL_HOOK_HANDLER:
 
 ; call hook handler
     mov eax, 1A2B3C00h
-    jmp TRAMPOLINE_EXIT 
+    jmp TRAMPOLINE_EXIT
 
 CALL_NET_OUTRO: ; this is where the handler returns...
 
@@ -103,6 +105,7 @@ TRAMPOLINE_EXIT:
     
     jmp eax ; ATTENTION: In case of hook handler we will return to CALL_NET_OUTRO, otherwise to the caller...
     
+Trampoline_ASM_X86_DATA::
 ; outro signature, to automatically determine code size
     db 78h
     db 56h

--- a/src/trampolinex86.asm
+++ b/src/trampolinex86.asm
@@ -6,7 +6,6 @@
 .code
 
 public Trampoline_ASM_X86@0
-
 public Trampoline_ASM_X86_DATA
 
 Trampoline_ASM_X86@0 PROC


### PR DESCRIPTION
* Modify the way the assembly code trampoline size is calculated using by using labels to get the exact size without doing a memory scan of the code to find the trailing signature
* Switch to using the static gtest library to match our detours.lib and corehook.dll projects target
* Update readme with more information on using 'msbuild'
* Refactor some variable declarations for better code readability  