### PR TITLE
test: Fix DetourGetHookBypassAddress test by supplying the second par…

### DIFF
--- a/msvc/corehook-test/detours_test.cpp
+++ b/msvc/corehook-test/detours_test.cpp
@@ -81,7 +81,8 @@ TEST_F(DetoursTest, ShouldFailWhenInstallingMaxHookCount) {
     }
 }
 TEST_F(DetoursTest, GetHookBypassAddress_Should_Return_Invalid_Handle_With_Bad_Hook_Handle) {
-    EXPECT_EQ(ERROR_INVALID_HANDLE, DetourGetHookBypassAddress(nullptr, nullptr));
+    PVOID *ppHookBypassAddress = NULL;
+    EXPECT_EQ(ERROR_INVALID_HANDLE, DetourGetHookBypassAddress(nullptr, &ppHookBypassAddress));
 }
 TEST_F(DetoursTest, GetHookBypassAddress_Should_Return_Invalid_Handle_With_Bad_Output_Address) {
     HOOK_TRACE_INFO pHandle;


### PR DESCRIPTION
…ameter to differentiate it from the remaining DetourGetHookBypassAddress tests