### PR TITLE
Update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,18 @@ You can find the Visual Studio solution inside [the msvc folder](/msvc). You can
 An example for building the X64 `corehook64.dll` in the Release configuration:
 
 ```
+msbuild msvc/corehook/detours.vcxproj /p:Configuration=Release /p:Platform=x64
+msbuild msvc/corehook/corehook.vcxproj /p:Configuration=Release /p:Platform=x64
+```
+
+To build the entire solution (which also builds the library tests), you can run:
+
+```
+nuget restore msvc/corehook.sln
 msbuild msvc/corehook.sln /p:Configuration=Release /p:Platform=x64
 ```
+
+
 ### NMAKE 
 
 You can find the build environments for your Visual Studio installation normally at `C:\Program Files (x86)\Microsoft Visual Studio\2017\[ProductType]\VC\Auxiliary\Build`, where `[ProductType]` is your version of Visual Studio: **(Community, Professional, or Enterprise)**.

--- a/msvc/corehook-test/DetoursTest.h
+++ b/msvc/corehook-test/DetoursTest.h
@@ -16,11 +16,14 @@ public:
 class DetoursTest : public testing::Test {
 
 protected:
-    virtual void SetUp() {
+    void SetUp() override
+    {
         DetourBarrierProcessAttach();
         DetourCriticalInitialize();
     }
-    virtual void TearDown() {
+
+    void TearDown() override
+    {
         DetourBarrierProcessDetach();
         DetourCriticalFinalize();
     }

--- a/msvc/corehook-test/detours_test.cpp
+++ b/msvc/corehook-test/detours_test.cpp
@@ -9,7 +9,7 @@ TEST_F(DetoursTest, SimpleDetoursUserFunctionTest) {
 // Detour CreateFileW with a non-existent file name
 TEST_F(DetoursTest, SimpleDetoursExportedFunctionTest) {
     const auto fileName = L"File.txt";
-    LPCWSTR fileNamePtr = NULL;
+    LPCWSTR fileNamePtr = nullptr;
 
     EXPECT_EQ(NO_ERROR, _dt.DetourExportedFunction(fileName, &fileNamePtr));
 
@@ -46,7 +46,7 @@ TEST_F(DetoursTest, FindFunctionNullTest) {
 
 TEST_F(DetoursTest, InstallInvalidHookParameterTest) {
     LONG callback = 0;
-    HOOK_TRACE_INFO hookHandle = { 0 };
+    HOOK_TRACE_INFO hookHandle = { nullptr };
     void(*testFunction)(int) = [](int i) { (VOID)i; };
 
     EXPECT_NE(NO_ERROR, DetourInstallHook(nullptr, nullptr, nullptr, nullptr));
@@ -81,7 +81,7 @@ TEST_F(DetoursTest, ShouldFailWhenInstallingMaxHookCount) {
     }
 }
 TEST_F(DetoursTest, GetHookBypassAddress_Should_Return_Invalid_Handle_With_Bad_Hook_Handle) {
-    PVOID *ppHookBypassAddress = NULL;
+    PVOID *ppHookBypassAddress = nullptr;
     EXPECT_EQ(ERROR_INVALID_HANDLE, DetourGetHookBypassAddress(nullptr, &ppHookBypassAddress));
 }
 TEST_F(DetoursTest, GetHookBypassAddress_Should_Return_Invalid_Handle_With_Bad_Output_Address) {

--- a/src/barrier.cpp
+++ b/src/barrier.cpp
@@ -174,7 +174,7 @@ LONG detour_set_acl(_In_ HOOK_ACL *pAcl,
 {
     ASSERT(IsValidPointer(pAcl, sizeof(HOOK_ACL)));
 
-    if (dwThreadCount > MAX_ACE_COUNT) {
+    if (dwThreadCount > MAX_ACL_COUNT) {
         return ERROR_INVALID_PARAMETER;
     }
 

--- a/src/barrier.h
+++ b/src/barrier.h
@@ -16,15 +16,14 @@ void detour_sleep(_In_ DWORD milliSeconds);
 //
 
 #define MAX_HOOK_COUNT              1024
-#define MAX_ACE_COUNT               128
+#define MAX_ACL_COUNT               128
 #define MAX_THREAD_COUNT            128
-#define MAX_PASSTHRU_SIZE           1024 * 64
 
 typedef struct _HOOK_ACL_
 {
     ULONG                   Count;
     BOOL                    IsExclusive;
-    ULONG                   Entries[MAX_ACE_COUNT];
+    ULONG                   Entries[MAX_ACL_COUNT];
 } HOOK_ACL;
 
 typedef struct _RUNTIME_INFO_


### PR DESCRIPTION
Fix build instructions by adding information about the 'nuget restore' required by the test project. Provide information on how to use msbuild to build by individual project if they don't want to restore and build the entire solution with tests.