### PR TITLE
Fix number of frames usage in DetourBarrierCallStackTrace

### DIFF
--- a/src/barrier.cpp
+++ b/src/barrier.cpp
@@ -76,7 +76,7 @@ void *detour_allocate_memory(_In_ BOOL   bZeroMemory,
     return result;
 }
 
-void detour_free_memory(void * pMemory)
+void detour_free_memory(void *pMemory)
 {
     DETOUR_ASSERT(pMemory != NULL);
 
@@ -567,7 +567,7 @@ LONG WINAPI DetourBarrierCallStackTrace(_Outptr_ PVOID *ppMethodArray,
         return ERROR_INVALID_FUNCTION;
     }
 
-    *pCapturedFramesCount = CaptureStackBackTrace(1, 32, ppMethodArray, NULL);
+    *pCapturedFramesCount = CaptureStackBackTrace(1, dwFramesToCapture, ppMethodArray, NULL);
 
     if (Backup != NULL) {
         DetourBarrierEndStackTrace(Backup);

--- a/src/barrier.h
+++ b/src/barrier.h
@@ -33,16 +33,16 @@ typedef struct _RUNTIME_INFO_
     // The hook this information entry belongs to. This allows a per thread and hook storage!
     DWORD           HLSIdent;
     // The return address of the current thread's hook handler.
-    void*           RetAddress;
+    PVOID           RetAddress;
     // The address of the return address of the current thread's hook handler.
-    void**          AddrOfRetAddr;
+    PVOID*          AddrOfRetAddr;
 } RUNTIME_INFO;
 
 typedef struct _THREAD_RUNTIME_INFO_
 {
     RUNTIME_INFO*        Entries;
     RUNTIME_INFO*        Current;
-    void*                Callback;
+    PVOID                Callback;
     BOOL                 IsProtected;
 } THREAD_RUNTIME_INFO, *PTHREAD_RUNTIME_INFO;
 

--- a/src/detours.cpp
+++ b/src/detours.cpp
@@ -128,16 +128,16 @@ struct _DETOUR_TRAMPOLINE
     PBYTE               pbRemain;       // first instruction after moved code. [free list]
     PBYTE               pbDetour;       // first instruction of detour function.
     HOOK_ACL            LocalACL;
-    void*               Callback;
+    PVOID               Callback;
     ULONG               HLSIndex;
     ULONG               HLSIdent;
     TRACED_HOOK_HANDLE  OutHandle;      // handle returned to user
-    void*               Trampoline;
-    void*               HookIntro;      // .NET Intro function
-    UCHAR*              OldProc;        // old target function
-    void*               HookProc;       // function we detour to
-    void*               HookOutro;      // .NET Outro function
-    int*                IsExecutedPtr;
+    PVOID               Trampoline;
+    PVOID               HookIntro;      // .NET Intro function
+    PBYTE               OldProc;        // old target function
+    PVOID               HookProc;       // function we detour to
+    PVOID               HookOutro;      // .NET Outro function
+    INT*                IsExecutedPtr;
     BYTE                rbTrampolineCode[DETOUR_TRAMPOLINE_CODE_SIZE];
 };
 
@@ -416,16 +416,16 @@ struct _DETOUR_TRAMPOLINE
     PBYTE               pbDetour;       // first instruction of detour function.
     BYTE                rbCodeIn[8];    // jmp [pbDetour]
     HOOK_ACL            LocalACL;
-    void*               Callback;
+    PVOID               Callback;
     ULONG               HLSIndex;
     ULONG               HLSIdent;
     TRACED_HOOK_HANDLE  OutHandle;      // handle returned to user
-    void*               Trampoline;
-    void*               HookIntro;      // .NET Intro function
-    UCHAR*              OldProc;        // old target function
-    void*               HookProc;       // function we detour to
-    void*               HookOutro;      // .NET Outro function
-    int*                IsExecutedPtr;
+    PVOID               Trampoline;
+    PVOID               HookIntro;      // .NET Intro function
+    PBYTE               OldProc;        // old target function
+    PVOID               HookProc;       // function we detour to
+    PVOID               HookOutro;      // .NET Outro function
+    INT*                IsExecutedPtr;
     BYTE                rbTrampolineCode[DETOUR_TRAMPOLINE_CODE_SIZE];
 };
 
@@ -828,16 +828,16 @@ struct _DETOUR_TRAMPOLINE
     PBYTE               pbRemain;       // first instruction after moved code. [free list]
     PBYTE               pbDetour;       // first instruction of detour function.
     HOOK_ACL            LocalACL;
-    void*               Callback;
+    PVOID               Callback;
     ULONG               HLSIndex;
     ULONG               HLSIdent;
     TRACED_HOOK_HANDLE  OutHandle;      // handle returned to user
-    void*               Trampoline;
-    void*               HookIntro;      // .NET Intro function
-    UCHAR*              OldProc;        // old target function
-    void*               HookProc;       // function we detour to
-    void*               HookOutro;      // .NET Outro function
-    int*                IsExecutedPtr;
+    PVOID               Trampoline;
+    PVOID               HookIntro;      // .NET Intro function
+    PBYTE               OldProc;        // old target function
+    PVOID               HookProc;       // function we detour to
+    PVOID               HookOutro;      // .NET Outro function
+    INT*                IsExecutedPtr;
     BYTE                rbTrampolineCode[DETOUR_TRAMPOLINE_CODE_SIZE];
 };
 
@@ -1002,16 +1002,16 @@ struct _DETOUR_TRAMPOLINE
     PBYTE               pbRemain;       // first instruction after moved code. [free list]
     PBYTE               pbDetour;       // first instruction of detour function.
     HOOK_ACL            LocalACL;
-    void*               Callback;
+    PVOID               Callback;
     ULONG               HLSIndex;
     ULONG               HLSIdent;
     TRACED_HOOK_HANDLE  OutHandle;      // handle returned to user
-    void*               Trampoline;
-    void*               HookIntro;      // .NET Intro function
-    UCHAR*              OldProc;        // old target function
-    void*               HookProc;       // function we detour to
-    void*               HookOutro;      // .NET Outro function
-    int*                IsExecutedPtr;
+    PVOID               Trampoline;
+    PVOID               HookIntro;      // .NET Intro function
+    PBYTE               OldProc;        // old target function
+    PVOID               HookProc;       // function we detour to
+    PVOID               HookOutro;      // .NET Outro function
+    INT*                IsExecutedPtr;
     BYTE                rbTrampolineCode[DETOUR_TRAMPOLINE_CODE_SIZE];
 };
 
@@ -1419,11 +1419,8 @@ static void detour_free_trampoline(PDETOUR_TRAMPOLINE pTrampoline)
     if( pTrampoline->OutHandle != NULL) {
         delete pTrampoline->OutHandle;
     }
-    if (pTrampoline->HLSIndex != -1) {
-        if (g_SlotList[pTrampoline->HLSIndex] == pTrampoline->HLSIdent)
-        {
-            g_SlotList[pTrampoline->HLSIndex] = 0;
-        }
+    if (pTrampoline->HLSIndex != (ULONG)-1 && g_SlotList[pTrampoline->HLSIndex] == pTrampoline->HLSIdent) {
+        g_SlotList[pTrampoline->HLSIndex] = 0;
     }
 
     memset(pTrampoline, 0, sizeof(*pTrampoline));
@@ -1632,7 +1629,7 @@ static LONG detour_align_from_target(PDETOUR_TRAMPOLINE pTrampoline, LONG obTarg
     return 0;
 }
 // cache calculated trampoline size since it should be static after the first time 
-static ULONG ___TrampolineSize = 0;
+static ULONG g_cachedTrampolineSize = 0;
 
 #ifdef DETOURS_X64
     extern "C" void __stdcall Trampoline_ASM_X64();
@@ -1672,19 +1669,21 @@ PBYTE detour_get_trampoline_ptr()
 #endif
     // Find the real start of the function if we encounter a jmp instruction
     if (*pbTrampoline == 0xE9) {
-        pbTrampoline += *((int*)(pbTrampoline + 1)) + 5;
+        pbTrampoline += *reinterpret_cast<int*>(pbTrampoline + 1) + 5;
     }
     return pbTrampoline;
 }
 
 ULONG detour_get_trampoline_size()
 {
-    if (___TrampolineSize != 0) {
-        return ___TrampolineSize;
+    // Trampoline size won't change during process run,
+    // so cache it and return it without re-calculating
+    if (g_cachedTrampolineSize != 0) {
+        return g_cachedTrampolineSize;
     }
 
 #if defined(DETOURS_X64)
-    ___TrampolineSize = static_cast<ULONG>(
+    g_cachedTrampolineSize = static_cast<ULONG>(
         (reinterpret_cast<PBYTE>(Trampoline_ASM_X64_DATA) - reinterpret_cast<PBYTE>(Trampoline_ASM_X64_CODE)));
 #elif defined(DETOURS_X86)  
     ___TrampolineSize = static_cast<ULONG>(
@@ -1696,7 +1695,7 @@ ULONG detour_get_trampoline_size()
     ___TrampolineSize = static_cast<ULONG>(
         (reinterpret_cast<PBYTE>(Trampoline_ASM_ARM64_DATA) - reinterpret_cast<PBYTE>(Trampoline_ASM_ARM64_CODE)));
 #endif
-    return ___TrampolineSize;
+    return g_cachedTrampolineSize;
 }
 
 static UINT WINAPI detour_barrier_intro(_In_ DETOUR_TRAMPOLINE *pHandle,

--- a/src/detours.cpp
+++ b/src/detours.cpp
@@ -1686,13 +1686,13 @@ ULONG detour_get_trampoline_size()
     g_cachedTrampolineSize = static_cast<ULONG>(
         (reinterpret_cast<PBYTE>(Trampoline_ASM_X64_DATA) - reinterpret_cast<PBYTE>(Trampoline_ASM_X64_CODE)));
 #elif defined(DETOURS_X86)  
-    ___TrampolineSize = static_cast<ULONG>(
+    g_cachedTrampolineSize = static_cast<ULONG>(
         (reinterpret_cast<PBYTE>(Trampoline_ASM_X86_DATA) - detour_get_trampoline_ptr()));
 #elif defined(DETOURS_ARM)
-    ___TrampolineSize = static_cast<ULONG>(
+    g_cachedTrampolineSize = static_cast<ULONG>(
         (reinterpret_cast<PBYTE>(Trampoline_ASM_ARM_DATA) - reinterpret_cast<PBYTE>(Trampoline_ASM_ARM_CODE)));
 #elif defined(DETOURS_ARM64)
-    ___TrampolineSize = static_cast<ULONG>(
+    g_cachedTrampolineSize = static_cast<ULONG>(
         (reinterpret_cast<PBYTE>(Trampoline_ASM_ARM64_DATA) - reinterpret_cast<PBYTE>(Trampoline_ASM_ARM64_CODE)));
 #endif
     return g_cachedTrampolineSize;


### PR DESCRIPTION
* Rename global variable ___TrampolineSize to g_cachedTrampolineSize

* Rename types of the members of the _DETOUR_TRAMPOLINE structures to better match the rest of the code