### PR TITLE
style: Rename tests to match Google suggested style

### DIFF
--- a/msvc/corehook-test/DetoursTest.h
+++ b/msvc/corehook-test/DetoursTest.h
@@ -1,6 +1,5 @@
 #pragma once
-#include "detours.h"
-#include <memory>
+#include "corehook.h"
 
 class Detours {
 

--- a/msvc/corehook-test/corehook-test.vcxproj
+++ b/msvc/corehook-test/corehook-test.vcxproj
@@ -95,7 +95,7 @@
     <IncludePath>../../src;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemGroup>
-    <ClInclude Include="hook.h" />
+    <ClInclude Include="corehook.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="DetoursTest.h" />
   </ItemGroup>

--- a/msvc/corehook-test/corehook.h
+++ b/msvc/corehook-test/corehook.h
@@ -2,7 +2,8 @@
 
 #ifndef COREHOOK_TEST_H_
 #define COREHOOK_TEST_H_
-
+#include "detours.h"
+#include <memory>
 
 #endif  // COREHOOK_TEST_H_
 

--- a/msvc/corehook-test/detours_test.cpp
+++ b/msvc/corehook-test/detours_test.cpp
@@ -80,14 +80,14 @@ TEST_F(DetoursTest, ShouldFailWhenInstallingMaxHookCount) {
         }
     }
 }
-TEST_F(DetoursTest, GetHookBypassAddress_Should_Return_Invalid_Handle_With_Bad_Hook_Handle) {
+TEST_F(DetoursTest, GetHookBypassAddressShouldReturnInvalidHandleWithBadHookHandle) {
     PVOID *ppHookBypassAddress = nullptr;
     EXPECT_EQ(ERROR_INVALID_HANDLE, DetourGetHookBypassAddress(nullptr, &ppHookBypassAddress));
 }
-TEST_F(DetoursTest, GetHookBypassAddress_Should_Return_Invalid_Handle_With_Bad_Output_Address) {
+TEST_F(DetoursTest, GetHookBypassAddressShouldReturnInvalidHandleWithBadOutputAddress) {
     HOOK_TRACE_INFO pHandle;
     EXPECT_EQ(ERROR_INVALID_PARAMETER, DetourGetHookBypassAddress(&pHandle, nullptr));
 }
-TEST_F(DetoursTest, GetHookBypassAddress_Should_Return_Invalid_Handle_With_Bad_Hook_Handle_and_Output_Address) {
+TEST_F(DetoursTest, GetHookBypassAddressShouldReturnInvalidHandleWithBadHookHandleandOutputAddress) {
     EXPECT_EQ(ERROR_INVALID_HANDLE, DetourGetHookBypassAddress(nullptr, nullptr));
 }


### PR DESCRIPTION
The suggested style can be found here: https://github.com/google/googletest/blob/master/googletest/docs/faq.md#why-should-test-case-names-and-test-names-not-contain-underscore