### PR TITLE
Update binaries build structure

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,7 +24,7 @@ skip_commits:
     - '**/*.md'
   
 after_build:
-  7z a corehook-%CONFIGURATION%-%PLATFORM%.zip %APPVEYOR_BUILD_FOLDER%\*\%CONFIGURATION%\corehook*.dll
+  7z a corehook-%CONFIGURATION%-%PLATFORM%.zip %APPVEYOR_BUILD_FOLDER%\bin\%PLATFORM%\%CONFIGURATION%\corehook*.dll
 
 artifacts:
 - path: corehook-%CONFIGURATION%-%PLATFORM%.zip

--- a/README.md
+++ b/README.md
@@ -13,7 +13,17 @@ For [CoreHook](https://github.com/unknownv2/CoreHook), the [Microsoft Detours](h
 
 ## Building
 
-Building the DLL requires Visual Studio and there are three options: You can build the DLL by using the `Visual Studio IDE` or `msbuild` within the `Developer Command Prompt`, `cmake`, or `nmake` (it has been tested with `Visual Studio 2017` only). 
+Building the DLL requires Visual Studio and that can be accomplished by using `cmake` or the tools that come with `Visual Studio`. This can be the `Visual Studio IDE` or `msbuild` within the `Developer Command Prompt`.
+
+### CMake 
+
+You can also build the library using CMake. You can run the `build/win-vs-2017.cmd` file to build for the `x86` and `x64` architectures. This also gives you the option to generate and build with an older version of `Visual Studio` such as `VS 2015` or `VS 2013`.
+
+You can build by running these commands from the root of the repository:
+```
+cd build
+win-vs-2017.cmd
+```
 
 ### Visual Studio
 
@@ -33,46 +43,6 @@ nuget restore msvc/corehook.sln
 msbuild msvc/corehook.sln /p:Configuration=Release /p:Platform=x64
 ```
 
-### CMake 
-
-You can also build the library using CMake. You can run the `build/win-vs-2017.cmd` file to build for the `x86` and `x64` architectures. This also gives you the option to generate and build with an older version of `Visual Studio` such as `VS 2015` or `VS 2013`.
-
-You can build by running these commands from the root of the repository:
-```
-cd build
-win-vs-2017.cmd
-```
-
-### NMAKE 
-
-You can find the build environments for your Visual Studio installation normally at `C:\Program Files (x86)\Microsoft Visual Studio\2017\[ProductType]\VC\Auxiliary\Build`, where `[ProductType]` is your version of Visual Studio: **(Community, Professional, or Enterprise)**.
-
-### X86
-* Start the `vcvars32.bat`. Then `cd` to the `CoreHook.Hooking` directory, and run:
- ```
- nmake DETOURS_TARGET_PROCESSOR=X86
- ```
-### X64 
-* For X64, start the `vcvars64.bat`. Then `cd` to the `CoreHook.Hooking` directory, and run:
-
- ```
- nmake DETOURS_TARGET_PROCESSOR=X64
- ```
-
-### ARM
-
-* For ARM, start the `vcvarsx86_arm.bat`. Then `cd` to the `CoreHook.Hooking` directory, and run:
-
- ```
- nmake DETOURS_TARGET_PROCESSOR=ARM
- ```
-
- ### ARM64 (Unsupported, for future reference)
-* For ARM64, start the `vcvarsamd64_arm64.bat`. Then `cd` to the `CoreHook.Hooking` directory, and run:
- ```
- nmake DETOURS_TARGET_PROCESSOR=ARM64
- ```
-
 ### Binary Releases 
  You can also download the pre-built Windows binaries [here](https://github.com/unknownv2/CoreHook.Hooking/releases).
  
@@ -82,10 +52,10 @@ You can find the build environments for your Visual Studio installation normally
 
 ## Usage
 
-* For X86, the output directory is `bin.X86` and the output file is `corehook32.dll`.
-* For X64, the output directory is `bin.X64` and the output file is `corehook64.dll`.
-* For ARM, the output directory is `bin.ARM` and the output file is `corehook32.dll`.
-* For ARM64, the output directory is `bin.ARM64` and the output file is `corehook64.dll`.
+* For X86, the output directory is `bin/x86` and the output file is `corehook32.dll`.
+* For X64, the output directory is `bin/x64` and the output file is `corehook64.dll`.
+* For ARM, the output directory is `bin/ARM` and the output file is `corehook32.dll`.
+* For ARM64, the output directory is `bin/ARM64` and the output file is `corehook64.dll`.
 
 Copy the desired file for your target architecture to the output directory of the program that uses [CoreHook](https://github.com/unknownv2/CoreHook/).
 

--- a/msvc/corehook-test/corehook-test.vcxproj
+++ b/msvc/corehook-test/corehook-test.vcxproj
@@ -56,61 +56,50 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <IncludePath>../../src;$(IncludePath)</IncludePath>
-    <OutDir>..\..\bin.$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>..\..\bin\$(PlatformTarget)\$(Configuration)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>..\..\bin.$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>..\..\bin\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IncludePath>../../src;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <IncludePath>../../src;$(IncludePath)</IncludePath>
-    <OutDir>..\..\bin.$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>..\..\bin\$(PlatformTarget)\$(Configuration)\</OutDir>
     <WindowsSDKDesktopARMSupport>true</WindowsSDKDesktopARMSupport>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <IncludePath>../../src;$(IncludePath)</IncludePath>
-    <OutDir>..\..\bin.$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>..\..\bin\$(PlatformTarget)\$(Configuration)\</OutDir>
     <WindowsSDKDesktopARMSupport>true</WindowsSDKDesktopARMSupport>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <IncludePath>../../src;$(IncludePath)</IncludePath>
-    <OutDir>..\..\bin.$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>..\..\bin\$(PlatformTarget)\$(Configuration)\</OutDir>
     <WindowsSDKDesktopARMSupport>true</WindowsSDKDesktopARMSupport>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <IncludePath>../../src;$(IncludePath)</IncludePath>
-    <OutDir>..\..\bin.$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>..\..\bin\$(PlatformTarget)\$(Configuration)\</OutDir>
     <WindowsSDKDesktopARMSupport>true</WindowsSDKDesktopARMSupport>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>..\..\bin.$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>..\..\bin\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IncludePath>../../src;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>..\..\bin.$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>..\..\bin\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IncludePath>../../src;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemGroup>
     <ClInclude Include="corehook.h" />
-    <ClInclude Include="pch.h" />
     <ClInclude Include="DetoursTest.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="detours_test.cpp" />
-    <ClCompile Include="pch.cpp">
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
-    </ClCompile>
     <ClCompile Include="DetoursTest.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -128,8 +117,6 @@
   </ImportGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
@@ -146,8 +133,6 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
@@ -163,8 +148,6 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
@@ -180,8 +163,6 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>X64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
@@ -200,8 +181,6 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
@@ -219,8 +198,6 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
@@ -235,8 +212,6 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
@@ -251,8 +226,6 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>X64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>

--- a/msvc/corehook/corehook.vcxproj
+++ b/msvc/corehook/corehook.vcxproj
@@ -144,49 +144,49 @@
     <IncludePath>../../src;$(IncludePath)</IncludePath>
     <LibraryPath>$(LibraryPath)</LibraryPath>
     <TargetName>$(ProjectName)$(PlatformArchitecture)</TargetName>
-    <OutDir>..\..\bin.$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>..\..\bin\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\corehook\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <TargetName>$(ProjectName)$(PlatformArchitecture)</TargetName>
     <IncludePath>../../src;$(IncludePath)</IncludePath>
-    <OutDir>..\..\bin.$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>..\..\bin\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\corehook\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <TargetName>$(ProjectName)32</TargetName>
     <IncludePath>../../src;$(IncludePath)</IncludePath>
-    <OutDir>..\..\bin.$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>..\..\bin\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\corehook\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <TargetName>$(ProjectName)64</TargetName>
     <IncludePath>../../src;$(IncludePath)</IncludePath>
-    <OutDir>..\..\bin.$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>..\..\bin\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\corehook\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <TargetName>$(ProjectName)$(PlatformArchitecture)</TargetName>
     <IncludePath>../../src;$(IncludePath)</IncludePath>
-    <OutDir>..\..\bin.$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>..\..\bin\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\corehook\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <TargetName>$(ProjectName)32</TargetName>
     <IncludePath>../../src;$(IncludePath)</IncludePath>
-    <OutDir>..\..\bin.$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>..\..\bin\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\corehook\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <TargetName>$(ProjectName)64</TargetName>
     <IncludePath>../../src;$(IncludePath)</IncludePath>
-    <OutDir>..\..\bin.$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>..\..\bin\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\corehook\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TargetName>$(ProjectName)$(PlatformArchitecture)</TargetName>
     <IncludePath>../../src;$(IncludePath)</IncludePath>
-    <OutDir>..\..\bin.$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>..\..\bin\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\corehook\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/msvc/corehook/detours.vcxproj
+++ b/msvc/corehook/detours.vcxproj
@@ -166,35 +166,35 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>..\..\bin.$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>..\..\bin\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\detours\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <IntDir>$(Platform)\$(Configuration)\detours\</IntDir>
-    <OutDir>..\..\bin.$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>..\..\bin\$(PlatformTarget)\$(Configuration)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>..\..\bin.$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>..\..\bin\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\detours\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>..\..\bin.$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>..\..\bin\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\detours\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
-    <OutDir>..\..\bin.$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>..\..\bin\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\detours\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
-    <OutDir>..\..\bin.$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>..\..\bin\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\detours\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <OutDir>..\..\bin.$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>..\..\bin\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\detours\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <OutDir>..\..\bin.$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>..\..\bin\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\detours\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">


### PR DESCRIPTION
Output the build files to the 'bin' and create the zip files for the binaries without any sub-folders in the release artifacts.