### PR TITLE
Update detours library code to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Building the DLL requires Visual Studio and that can be accomplished by using `c
 
 ## CMake 
 
-You can build the library using CMake by running `build.cmd`, which builds the library for the `x86` and `x64` architectures. This also gives you the option to generate and build the library with an older version of `Visual Studio` such as `VS 2015` or `VS 2013`.
+You can build the library using CMake by running [`build.cmd`](build.cmd), which builds the library for the `x86` and `x64` architectures. This also gives you the option to generate and build the library with an older version of `Visual Studio` such as `VS 2015` or `VS 2013`.
 
 ## Visual Studio
 

--- a/README.md
+++ b/README.md
@@ -7,25 +7,26 @@
 
 For [CoreHook](https://github.com/unknownv2/CoreHook), the [Microsoft Detours](https://github.com/Microsoft/Detours) package serves as a good binary hooking module since it supports x86, x86_64, ARM, and ARM64, while [EasyHook](https://github.com/EasyHook/EasyHook) only supports x86 and x86_64. Since .NET Core supports the two ARM architectures, we can implement the necessary changes to support those architectures for CoreHook.
 
-## Supported Platforms
+# Supported Platforms
 
 `X86, X64, and ARM`. If you have a *Windows on ARM* device to test `ARM64` with, pull requests and contributions are all welcome!
 
-## Building
+# Binary Releases 
+ You can download the pre-built Windows binaries [here](https://github.com/unknownv2/CoreHook.Hooking/releases).
+ 
+ For `x86, x64`, extract the zip corresponding to your target architecture, then place the `corehook32.dll` and/or `corehook64.dll` in the build output directory of your program.
+ 
+ For `ARM, ARM64`,  extract the zip corresponding to your target architecture, then place the `corehook32.dll` and/or `corehook64.dll` in the output directory of your published program, created either from using the [Publishing Script](https://github.com/unknownv2/CoreHook#publishing-script) or the `dotnet publish` command.
+
+# Building
 
 Building the DLL requires Visual Studio and that can be accomplished by using `cmake` or the tools that come with `Visual Studio`. This can be the `Visual Studio IDE` or `msbuild` within the `Developer Command Prompt`.
 
-### CMake 
+## CMake 
 
-You can also build the library using CMake. You can run the `build/win-vs-2017.cmd` file to build for the `x86` and `x64` architectures. This also gives you the option to generate and build with an older version of `Visual Studio` such as `VS 2015` or `VS 2013`.
+You can build the library using CMake by running `build.cmd`, which builds the library for the `x86` and `x64` architectures. This also gives you the option to generate and build the library with an older version of `Visual Studio` such as `VS 2015` or `VS 2013`.
 
-You can build by running these commands from the root of the repository:
-```
-cd build
-win-vs-2017.cmd
-```
-
-### Visual Studio
+## Visual Studio
 
 You can find the Visual Studio solution inside [the msvc folder](/msvc). You can choose a configuration (**Debug|Release**) and a platform (**X86|X64|ARM|ARM64**) and build. 
 
@@ -43,14 +44,8 @@ nuget restore msvc/corehook.sln
 msbuild msvc/corehook.sln /p:Configuration=Release /p:Platform=x64
 ```
 
-### Binary Releases 
- You can also download the pre-built Windows binaries [here](https://github.com/unknownv2/CoreHook.Hooking/releases).
- 
- For `x86, x64`, extract the zip corresponding to your target architecture, then place the `corehook32.dll` and/or `corehook64.dll` in the build output directory of your program.
- 
- For `ARM, ARM64`,  extract the zip corresponding to your target architecture, then place the `corehook32.dll` and/or `corehook64.dll` in the output directory of your published program, created either from using the [Publishing Script](https://github.com/unknownv2/CoreHook#publishing-script) or the `dotnet publish` command.
 
-## Usage
+# Usage
 
 * For X86, the output directory is `bin/x86` and the output file is `corehook32.dll`.
 * For X64, the output directory is `bin/x64` and the output file is `corehook64.dll`.
@@ -60,7 +55,7 @@ msbuild msvc/corehook.sln /p:Configuration=Release /p:Platform=x64
 Copy the desired file for your target architecture to the output directory of the program that uses [CoreHook](https://github.com/unknownv2/CoreHook/).
 
 
-## Credits
+# Credits
 
 The hooking module is mostly based on the [EasyHook](https://github.com/EasyHook/EasyHook/blob/master/LICENSE) native module and the [Microsoft Detours](https://github.com/Microsoft/Detours/blob/master/LICENSE.md) library and this library wouldn't be possible without them. They are both MIT-licensed.
 

--- a/build.cmd
+++ b/build.cmd
@@ -1,4 +1,3 @@
-cd ../
 mkdir build32-vs2017
 mkdir build64-vs2017
 cd build32-vs2017
@@ -11,4 +10,3 @@ cmake --build build32-vs2017 --config Debug
 cmake --build build32-vs2017 --config Release
 cmake --build build64-vs2017 --config Debug
 cmake --build build64-vs2017 --config Release
-cd build

--- a/samples/Makefile
+++ b/samples/Makefile
@@ -39,8 +39,10 @@ all:
     @$(MAKE) /NOLOGO /$(MAKEFLAGS)
     cd "$(MAKEDIR)\echo"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS)
+!IF "$(DETOURS_TARGET_PROCESSOR)" != "ARM64"
     cd "$(MAKEDIR)\einst"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS)
+!ENDIF
 !IF "$(DETOURS_TARGET_PROCESSOR)" == "X86"
     cd "$(MAKEDIR)\excep"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS)
@@ -49,9 +51,11 @@ all:
     @$(MAKE) /NOLOGO /$(MAKEFLAGS)
     cd "$(MAKEDIR)\commem"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS)
+!IF "$(DETOURS_TARGET_PROCESSOR)" != "ARM64"
     cd "$(MAKEDIR)\findfunc"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS)
-!IF "$(DETOURS_TARGET_PROCESSOR)" != "ARM"
+!ENDIF
+!IF "$(DETOURS_TARGET_PROCESSOR)" != "ARM" && "$(DETOURS_TARGET_PROCESSOR)" != "ARM64"
     cd "$(MAKEDIR)\member"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS)
 !ENDIF
@@ -77,7 +81,7 @@ all:
     @$(MAKE) /NOLOGO /$(MAKEFLAGS)
     cd "$(MAKEDIR)\tracelnk"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS)
-!IF "$(DETOURS_TARGET_PROCESSOR)" != "ARM"
+!IF "$(DETOURS_TARGET_PROCESSOR)" != "ARM" && "$(DETOURS_TARGET_PROCESSOR)" != "ARM64"
     cd "$(MAKEDIR)\tryman"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS)
 !ENDIF
@@ -218,34 +222,42 @@ test:
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
     cd "$(MAKEDIR)\simple"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
+!IF "$(DETOURS_TARGET_PROCESSOR)" != "ARM64"
     cd "$(MAKEDIR)\slept"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
     cd "$(MAKEDIR)\setdll"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
     cd "$(MAKEDIR)\withdll"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
+!ENDIF
 !IF "$(DETOURS_TARGET_PROCESSOR)" == "X86"
     cd "$(MAKEDIR)\cping"
 #   @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
 !ENDIF
     cd "$(MAKEDIR)\disas"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
+!IF "$(DETOURS_TARGET_PROCESSOR)" != "ARM64"
     cd "$(MAKEDIR)\dtest"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
+!ENDIF
     cd "$(MAKEDIR)\dumpe"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
     cd "$(MAKEDIR)\dumpi"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
     cd "$(MAKEDIR)\echo"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
+!IF "$(DETOURS_TARGET_PROCESSOR)" != "ARM64"
     cd "$(MAKEDIR)\einst"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
+!ENDIF
 !IF "$(DETOURS_TARGET_PROCESSOR)" == "X86"
     cd "$(MAKEDIR)\excep"
 #   @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
 !ENDIF
+!IF "$(DETOURS_TARGET_PROCESSOR)" != "ARM64"
     cd "$(MAKEDIR)\comeasy"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
+
     cd "$(MAKEDIR)\commem"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
     cd "$(MAKEDIR)\findfunc"
@@ -254,10 +266,12 @@ test:
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
     cd "$(MAKEDIR)\region"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
+!ENDIF
 !IF "$(DETOURS_TARGET_PROCESSOR)" == "X64" || "$(DETOURS_TARGET_PROCESSOR)" == "IA64"
     cd "$(MAKEDIR)\talloc"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
 !ENDIF
+!IF "$(DETOURS_TARGET_PROCESSOR)" != "ARM64"
     cd "$(MAKEDIR)\traceapi"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
     cd "$(MAKEDIR)\tracebld"
@@ -268,12 +282,15 @@ test:
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
     cd "$(MAKEDIR)\traceser"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
+!ENDIF
 #    cd "$(MAKEDIR)\tracessl"
 #    @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
 #    cd "$(MAKEDIR)\tracetcp"
 #    @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
+!IF "$(DETOURS_TARGET_PROCESSOR)" != "ARM64"
     cd "$(MAKEDIR)\tracelnk"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
+!ENDIF
     cd "$(MAKEDIR)\impmunge"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
     cd "$(MAKEDIR)"

--- a/samples/cping/cping.cpp
+++ b/samples/cping/cping.cpp
@@ -115,6 +115,7 @@ STDAPI PingMessage(PCSTR msg, ...)
 
     va_start(args, msg);
     hr = StringCchVPrintfA(s_szMessageBuf, ARRAYSIZE(s_szMessageBuf), msg, args);
+    va_end(args);
     if (FAILED(hr)) {
         return hr;
     }
@@ -140,6 +141,7 @@ BOOLEAN CheckResult(HRESULT hr, PCSTR pszMsg, ...)
 
         va_start(args, pszMsg);
         ihr = StringCchVPrintfA(s_szMessageBuf, ARRAYSIZE(s_szMessageBuf), pszMsg, args);
+        va_end(args);
         if (FAILED(ihr)) {
             return FALSE;
         }
@@ -1410,10 +1412,9 @@ HRESULT CSampleRecord::Measure(IPing *pIPing, LONG cbToClient, LONG cbToServer)
         hr = Catch_IPing_PingToClient(pIPing, &pszString);
         llEnd = GetTimeStamp();
 
-        LONG cb = (LONG)strlen(pszString) + 1;
-        ASSERT(cb == cbToClient);
-
         if (pszString) {
+            LONG cb = (LONG)strlen(pszString) + 1;
+            ASSERT(cb == cbToClient);
             CoTaskMemFree(pszString);
             pszString = NULL;
         }

--- a/samples/einst/Makefile
+++ b/samples/einst/Makefile
@@ -9,6 +9,19 @@
 
 !include ..\common.mak
 
+# ARM64 does not like base addresses below 4GB.
+# Append two extra zeros for it.
+#
+!if "$(DETOURS_TARGET_PROCESSOR)" == "ARM64"
+EDLL1X_BASE=0x710000000
+EDLL2X_BASE=0x720000000
+EDLL3X_BASE=0x730000000
+!else
+EDLL1X_BASE=0x7100000
+EDLL2X_BASE=0x7200000
+EDLL3X_BASE=0x7300000
+!endif
+
 LIBS=$(LIBS) kernel32.lib user32.lib
 
 all: dirs \
@@ -60,7 +73,7 @@ $(BIND)\edll1x$(DETOURS_BITS).dll : $(OBJD)\edll1x.obj $(DEPS)
         $(OBJD)\edll1x.obj /LD \
         /link $(LINKFLAGS) $(LIBS) \
         /subsystem:windows \
-        /base:0x7100000
+        /base:$(EDLL1X_BASE)
 
 $(OBJD)\edll1x$(DETOURS_BITS).bsc : $(OBJD)\edll1x.obj
     bscmake /v /n /o $@ $(OBJD)\edll1x.sbr
@@ -72,7 +85,7 @@ $(BIND)\edll2x$(DETOURS_BITS).dll : $(OBJD)\edll2x.obj $(DEPS)
         $(OBJD)\edll2x.obj /LD \
         /link $(LINKFLAGS) $(LIBS) \
         /subsystem:console \
-        /base:0x7200000
+        /base:$(EDLL2X_BASE)
 
 $(OBJD)\edll2x$(DETOURS_BITS).bsc : $(OBJD)\edll2x.obj
     bscmake /v /n /o $@ $(OBJD)\edll2x.sbr
@@ -84,7 +97,7 @@ $(BIND)\edll3x$(DETOURS_BITS).dll : $(OBJD)\edll3x.obj $(DEPS)
         $(OBJD)\edll3x.obj /LD \
         /link $(LINKFLAGS) $(LIBS) \
         /subsystem:console \
-        /base:0x7300000
+        /base:$(EDLL3X_BASE)
 
 $(OBJD)\edll3x$(DETOURS_BITS).bsc : $(OBJD)\edll3x.obj
     bscmake /v /n /o $@ $(OBJD)\edll3x.sbr

--- a/samples/findfunc/Makefile
+++ b/samples/findfunc/Makefile
@@ -9,6 +9,17 @@
 
 !include ..\common.mak
 
+# ARM64 does not like base addresses below 4GB.
+# Append two extra zeros for it.
+#
+!if "$(DETOURS_TARGET_PROCESSOR)" == "ARM64"
+TARGET_BASE=0x190000000
+EXTEND_BASE=0x1a0000000
+!else
+TARGET_BASE=0x1900000
+EXTEND_BASE=0x1a00000
+!endif
+
 LIBS=$(LIBS) kernel32.lib
 
 ##############################################################################
@@ -44,7 +55,7 @@ $(BIND)\target$(DETOURS_BITS).dll $(BIND)\target$(DETOURS_BITS).lib: \
         $(OBJD)\target.obj $(OBJD)\target.res \
         /link $(LINKFLAGS) /subsystem:console \
         /export:Target \
-        /base:0x1900000 \
+        /base:$(TARGET_BASE) \
         $(LIBS)
 
 $(OBJD)\target$(DETOURS_BITS).bsc : $(OBJD)\target.obj
@@ -60,7 +71,7 @@ $(BIND)\extend$(DETOURS_BITS).dll $(BIND)\extend$(DETOURS_BITS).lib: \
         $(OBJD)\extend.obj $(OBJD)\extend.res \
         /link $(LINKFLAGS) /subsystem:console \
         /export:DetourFinishHelperProcess,@1,NONAME \
-        /base:0x1a00000 \
+        /base:$(EXTEND_BASE) \
         $(LIBS)
 
 $(OBJD)\extend$(DETOURS_BITS).bsc : $(OBJD)\extend.obj

--- a/samples/slept/slept.cpp
+++ b/samples/slept/slept.cpp
@@ -67,7 +67,7 @@ DWORD WINAPI TestTicksEx(DWORD Add)
 
         Add = pdw[Add] - Add;
 
-        delete pdw;
+        delete [] pdw;
     }
     else {
         Add = dwSlept + Add;

--- a/samples/traceapi/_win32.cpp
+++ b/samples/traceapi/_win32.cpp
@@ -12741,18 +12741,18 @@ BOOL __stdcall Mine_CreateProcessA(LPCSTR lpApplicationName,
 
     BOOL rv = 0;
     __try {
-        rv = DetourCreateProcessWithDllA(lpApplicationName,
-                                         lpCommandLine,
-                                         lpProcessAttributes,
-                                         lpThreadAttributes,
-                                         bInheritHandles,
-                                         dwCreationFlags,
-                                         lpEnvironment,
-                                         lpCurrentDirectory,
-                                         lpStartupInfo,
-                                         lpProcessInformation,
-                                         s_szDllPath,
-                                         Real_CreateProcessA);
+        rv = DetourCreateProcessWithDllExA(lpApplicationName,
+                                           lpCommandLine,
+                                           lpProcessAttributes,
+                                           lpThreadAttributes,
+                                           bInheritHandles,
+                                           dwCreationFlags,
+                                           lpEnvironment,
+                                           lpCurrentDirectory,
+                                           lpStartupInfo,
+                                           lpProcessInformation,
+                                           s_szDllPath,
+                                           Real_CreateProcessA);
     } __finally {
         _PrintExit("CreateProcessA(,,,,,,,,,) -> %x (proc:%d/%p, thrd:%d/%p\n", rv,
                    lpProcessInformation->dwProcessId,
@@ -12794,18 +12794,18 @@ BOOL __stdcall Mine_CreateProcessW(LPCWSTR lpApplicationName,
 
     BOOL rv = 0;
     __try {
-        rv = DetourCreateProcessWithDllW(lpApplicationName,
-                                         lpCommandLine,
-                                         lpProcessAttributes,
-                                         lpThreadAttributes,
-                                         bInheritHandles,
-                                         dwCreationFlags,
-                                         lpEnvironment,
-                                         lpCurrentDirectory,
-                                         lpStartupInfo,
-                                         lpProcessInformation,
-                                         s_szDllPath,
-                                         Real_CreateProcessW);
+        rv = DetourCreateProcessWithDllExW(lpApplicationName,
+                                           lpCommandLine,
+                                           lpProcessAttributes,
+                                           lpThreadAttributes,
+                                           bInheritHandles,
+                                           dwCreationFlags,
+                                           lpEnvironment,
+                                           lpCurrentDirectory,
+                                           lpStartupInfo,
+                                           lpProcessInformation,
+                                           s_szDllPath,
+                                           Real_CreateProcessW);
     } __finally {
         _PrintExit("CreateProcessW(,,,,,,,,,) -> %x (proc:%d/%p, thrd:%d/%p\n", rv,
                    lpProcessInformation->dwProcessId,

--- a/src/detours.cpp
+++ b/src/detours.cpp
@@ -992,7 +992,29 @@ const ULONG DETOUR_TRAMPOLINE_CODE_SIZE = 344;
 struct _DETOUR_TRAMPOLINE
 {
     // An ARM64 instruction is 4 bytes long.
-    BYTE                rbCode[64];     // target code + jmp to pbRemain
+    //
+    // The overwrite is always 2 instructions plus a literal, so 16 bytes, 4 instructions.
+    //
+    // Copied instructions can expand.
+    //
+    // The scheme using MovImmediate can cause an instruction
+    // to grow as much as 6 times.
+    // That would be Bcc or Tbz with a large address space:
+    //   4 instructions to form immediate
+    //   inverted tbz/bcc
+    //   br
+    //
+    // An expansion of 4 is not uncommon -- bl/blr and small address space:
+    //   3 instructions to form immediate
+    //   br or brl
+    //
+    // A theoretical maximum for rbCode is thefore 4*4*6 + 16 = 112 (another 16 for jmp to pbRemain).
+    //
+    // With literals, the maximum expansion is 5, including the literals: 4*4*5 + 16 = 96.
+    //
+    // The number is rounded up to 128. m_rbScratchDst should match this.
+    //
+    BYTE                rbCode[128];     // target code + jmp to pbRemain
     BYTE                cbCode;         // size of moved target code.
     BYTE                cbCodeBreak[3]; // padding to make debugging easier.
     BYTE                rbRestore[24];  // original target code.
@@ -1015,7 +1037,7 @@ struct _DETOUR_TRAMPOLINE
     BYTE                rbTrampolineCode[DETOUR_TRAMPOLINE_CODE_SIZE];
 };
 
-C_ASSERT(sizeof(_DETOUR_TRAMPOLINE) == 1056);
+C_ASSERT(sizeof(_DETOUR_TRAMPOLINE) == 1120);
 
 enum {
     SIZE_OF_JMP = 8
@@ -1063,6 +1085,15 @@ inline PBYTE detour_gen_brk(PBYTE pbCode, PBYTE pbLimit)
     return pbCode;
 }
 
+inline INT64 detour_sign_extend(UINT64 value, UINT bits)
+{
+    const UINT left = 64 - bits;
+    const INT64 m1 = -1;
+    const INT64 wide = (INT64)(value << left);
+    const INT64 sign = (wide < 0) ? (m1 << left) : 0;
+    return value | sign;
+}
+
 inline PBYTE detour_skip_jmp(PBYTE pbCode, PVOID *ppGlobals)
 {
     if (pbCode == NULL) {
@@ -1075,19 +1106,72 @@ inline PBYTE detour_skip_jmp(PBYTE pbCode, PVOID *ppGlobals)
     // Skip over the import jump if there is one.
     pbCode = (PBYTE)pbCode;
     ULONG Opcode = fetch_opcode(pbCode);
+
     if ((Opcode & 0x9f00001f) == 0x90000010) {           // adrp  x16, IAT
-        ULONG Opcode2 = fetch_opcode(pbCode+4);
+        ULONG Opcode2 = fetch_opcode(pbCode + 4);
 
         if ((Opcode2 & 0xffe003ff) == 0xf9400210) {      // ldr   x16, [x16, IAT]
-            ULONG Opcode3 = fetch_opcode(pbCode+8);
+            ULONG Opcode3 = fetch_opcode(pbCode + 8);
 
             if (Opcode3 == 0xd61f0200) {                 // br    x16
 
-                ULONG PageOffset = ((Opcode & 0x60000000) >> 29) | ((Opcode & 0x00ffffe0) >> 3);
-                PageOffset = (LONG)(Opcode << 11) >> 11;
+/* https://static.docs.arm.com/ddi0487/bb/DDI0487B_b_armv8_arm.pdf
+    The ADRP instruction shifts a signed, 21-bit immediate left by 12 bits, adds it to the value of the program counter with
+    the bottom 12 bits cleared to zero, and then writes the result to a general-purpose register. This permits the
+    calculation of the address at a 4KB aligned memory region. In conjunction with an ADD (immediate) instruction, or
+    a Load/Store instruction with a 12-bit immediate offset, this allows for the calculation of, or access to, any address
+    within +/- 4GB of the current PC.
 
-                PBYTE pbTarget = (PBYTE)(((ULONG64)pbCode & 0xfffffffffffff000ULL) + PageOffset +
-                                         ((Opcode2 >> 10) & 0xfff));
+PC-rel. addressing
+    This section describes the encoding of the PC-rel. addressing instruction class. The encodings in this section are
+    decoded from Data Processing -- Immediate on page C4-226.
+    Add/subtract (immediate)
+    This section describes the encoding of the Add/subtract (immediate) instruction class. The encodings in this section
+    are decoded from Data Processing -- Immediate on page C4-226.
+    Decode fields
+    Instruction page
+    op
+    0 ADR
+    1 ADRP
+
+C6.2.10 ADRP
+    Form PC-relative address to 4KB page adds an immediate value that is shifted left by 12 bits, to the PC value to
+    form a PC-relative address, with the bottom 12 bits masked out, and writes the result to the destination register.
+    ADRP <Xd>, <label>
+    imm = SignExtend(immhi:immlo:Zeros(12), 64);
+
+    31  30 29 28 27 26 25 24 23 5    4 0
+    1   immlo  1  0  0  0  0  immhi  Rd
+         9             0
+
+Rd is hardcoded as 0x10 above.
+Immediate is 21 signed bits split into 2 bits and 19 bits, and is scaled by 4K.
+*/
+                UINT64 const pageLow2 = (Opcode >> 29) & 3;
+                UINT64 const pageHigh19 = (Opcode >> 5) & ~(~0ui64 << 19);
+                INT64 const page = detour_sign_extend((pageHigh19 << 2) | pageLow2, 21) << 12;
+
+                /* https://static.docs.arm.com/ddi0487/bb/DDI0487B_b_armv8_arm.pdf
+
+                    C6.2.101 LDR (immediate)
+                    Load Register (immediate) loads a word or doubleword from memory and writes it to a register. The address that is
+                    used for the load is calculated from a base register and an immediate offset.
+                    The Unsigned offset variant scales the immediate offset value by the size of the value accessed before adding it
+                    to the base register value.
+
+                Unsigned offset
+                64-bit variant Applies when size == 11.
+                    31 30 29 28  27 26 25 24  23 22  21   10   9 5   4 0
+                     1  x  1  1   1  0  0  1   0  1  imm12      Rn    Rt
+                         F             9        4              200    10
+
+                That is, two low 5 bit fields are registers, hardcoded as 0x10 and 0x10 << 5 above,
+                then unsigned size-unscaled (8) 12-bit offset, then opcode bits 0xF94.
+                */
+                UINT64 const offset = ((Opcode2 >> 10) & ~(~0ui64 << 12)) << 3;
+
+                PBYTE const pbTarget = (PBYTE)((ULONG64)pbCode & 0xfffffffffffff000ULL) + page + offset;
+
                 if (detour_is_imported(pbCode, pbTarget)) {
                     PBYTE pbNew = *(PBYTE *)pbTarget;
                     DETOUR_TRACE(("%p->%p: skipped over import table.\n", pbCode, pbNew));
@@ -1098,6 +1182,20 @@ inline PBYTE detour_skip_jmp(PBYTE pbCode, PVOID *ppGlobals)
     }
     return pbCode;
 }
+
+inline void detour_find_jmp_bounds(PBYTE pbCode,
+    PDETOUR_TRAMPOLINE *ppLower,
+    PDETOUR_TRAMPOLINE *ppUpper)
+{
+    // We have to place trampolines within +/- 2GB of code.
+    ULONG_PTR lo = detour_2gb_below((ULONG_PTR)pbCode);
+    ULONG_PTR hi = detour_2gb_above((ULONG_PTR)pbCode);
+    DETOUR_TRACE(("[%p..%p..%p]\n", lo, pbCode, hi));
+
+    *ppLower = (PDETOUR_TRAMPOLINE)lo;
+    *ppUpper = (PDETOUR_TRAMPOLINE)hi;
+}
+
 
 inline BOOL detour_does_code_end_function(PBYTE pbCode)
 {
@@ -1119,18 +1217,7 @@ inline ULONG detour_is_code_filler(PBYTE pbCode)
     }
     return 0;
 }
-inline void detour_find_jmp_bounds(PBYTE pbCode,
-                                   PDETOUR_TRAMPOLINE *ppLower,
-                                   PDETOUR_TRAMPOLINE *ppUpper)
-{
-    // We have to place trampolines within +/- 2GB of code.
-    ULONG_PTR lo = detour_2gb_below((ULONG_PTR)pbCode);
-    ULONG_PTR hi = detour_2gb_above((ULONG_PTR)pbCode);
-    DETOUR_TRACE(("[%p..%p..%p]\n", lo, pbCode, hi));
 
-    *ppLower = (PDETOUR_TRAMPOLINE)lo;
-    *ppUpper = (PDETOUR_TRAMPOLINE)hi;
-}
 #endif // DETOURS_ARM64
 
 //////////////////////////////////////////////// Trampoline Memory Management.
@@ -2503,7 +2590,7 @@ LONG WINAPI DetourAttachEx(_Inout_ PVOID *ppPointer,
         DETOUR_TRACE(("transaction conflict with thread id=%d\n", s_nPendingThreadId));
         return ERROR_INVALID_OPERATION;
     }
-
+    
     // If any of the pending operations failed, then we don't need to do this.
     if (s_nPendingError != NO_ERROR) {
         DETOUR_TRACE(("pending transaction error=%d\n", s_nPendingError));

--- a/src/detours.h
+++ b/src/detours.h
@@ -375,14 +375,26 @@ typedef struct _DETOUR_EXE_RESTORE
     IMAGE_DOS_HEADER    idh;
     union {
         IMAGE_NT_HEADERS    inh;
+#ifdef IMAGE_NT_OPTIONAL_HDR32_MAGIC    // some environments do not have this
         IMAGE_NT_HEADERS32  inh32;
+#endif
+#ifdef IMAGE_NT_OPTIONAL_HDR64_MAGIC    // some environments do not have this
         IMAGE_NT_HEADERS64  inh64;
+#endif
+#ifdef IMAGE_NT_OPTIONAL_HDR64_MAGIC    // some environments do not have this
         BYTE                raw[sizeof(IMAGE_NT_HEADERS64) +
                                 sizeof(IMAGE_SECTION_HEADER) * 32];
+#else
+        BYTE                raw[0x108 + sizeof(IMAGE_SECTION_HEADER) * 32];
+#endif
     };
     DETOUR_CLR_HEADER   clr;
 
 } DETOUR_EXE_RESTORE, *PDETOUR_EXE_RESTORE;
+
+#ifdef IMAGE_NT_OPTIONAL_HDR64_MAGIC
+C_ASSERT(sizeof(IMAGE_NT_HEADERS64) == 0x108);
+#endif
 
 typedef struct _DETOUR_EXE_HELPER
 {

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -1714,17 +1714,13 @@ BOOL CImage::Write(HANDLE hFile)
         m_nNextFileAddr = Max(m_SectionHeaders[n].PointerToRawData +
                               m_SectionHeaders[n].SizeOfRawData,
                               m_nNextFileAddr);
-#if 0
-        m_nNextVirtAddr = Max(m_SectionHeaders[n].VirtualAddress +
-                              m_SectionHeaders[n].Misc.VirtualSize,
-                              m_nNextVirtAddr);
-#else
+        // Old images have VirtualSize == 0 as a matter of course, e.g. NT 3.1.
+        // In which case, use SizeOfRawData instead.
         m_nNextVirtAddr = Max(m_SectionHeaders[n].VirtualAddress +
                               (m_SectionHeaders[n].Misc.VirtualSize
                                ? m_SectionHeaders[n].Misc.VirtualSize
                                : SectionAlign(m_SectionHeaders[n].SizeOfRawData)),
                               m_nNextVirtAddr);
-#endif
 
         m_nExtraOffset = Max(m_nNextFileAddr, m_nExtraOffset);
 


### PR DESCRIPTION
Add support for Intel EVEX( AVX512) and AMD XOP instructions and better support for the ARM64 architecture using the source from the original repository at https://github.com/Microsoft/Detours.